### PR TITLE
Default underenhet med samme orgnr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
     name: Build and publish image
     needs: test
 
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/INSERT-YOUR-BRANCH-HERE'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/default-underenhet-med-samme-orgnr'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ repositories {
 dependencies {
     testImplementation(kotlin("test"))
 
+    val kotestVerstion = "5.4.2"
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVerstion")
+
     val ktorVersion = "2.0.3"
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")

--- a/src/main/kotlin/no.nav.arbeidsgiver.mock.enhetsregisteret/api/repository/UnderenhetRepository.kt
+++ b/src/main/kotlin/no.nav.arbeidsgiver.mock.enhetsregisteret/api/repository/UnderenhetRepository.kt
@@ -12,7 +12,12 @@ class UnderenhetRepository {
     fun hentForUnderenhet(orgnr: String): Underenhet {
         log("hentForUnderenhet").info("Henter opplysninger for underenhet '${orgnr}'")
 
-        return UNDERENHETER.getOrDefault(orgnr, UNDERENHET)
+        return UNDERENHETER.getOrDefault(
+            orgnr,
+            UNDERENHET.copy(
+                organisasjonsnummer = orgnr
+            )
+        )
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/arbeidsgiver/mock/enhetsregisteret/api/repository/UnderenhetRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsgiver/mock/enhetsregisteret/api/repository/UnderenhetRepositoryTest.kt
@@ -1,0 +1,20 @@
+package no.nav.arbeidsgiver.mock.enhetsregisteret.api.repository
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class UnderenhetRepositoryTest {
+
+    @Test
+    fun `Skal hente mock underenhet fra test dataset`() {
+        val result = UnderenhetRepository().hentForUnderenhet("311545795").tilDto()
+
+        result.navn shouldBe "INNBRINGENDE LATTERMILD APE"
+        result.organisasjonsnummer shouldBe "311545795"
+    }
+
+    @Test
+    fun `Dersom ingen mock underenhet er funnet skal det returneres en default underenhet med orgnr som er lik orgnr i request parameter`() {
+        UnderenhetRepository().hentForUnderenhet("000000000").organisasjonsnummer shouldBe "000000000"
+    }
+}


### PR DESCRIPTION
For å unngå feil i sykefraværsstatistikk-api med melding "Orgnr hentet fra Enhetsregisteret samsvarer ikke med det medsendte orgnr" returneres en (default) undernehet med samme orgnr som request parameter dersom ingen mock data er funnet. 